### PR TITLE
Add nginx app names

### DIFF
--- a/p2/confs/app1-configmap.yaml
+++ b/p2/confs/app1-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app1-html
+  namespace: apps
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <head><title>App 1</title></head>
+      <body><h1>Hello from App 1</h1></body>
+    </html>

--- a/p2/confs/app1-deployment.yaml
+++ b/p2/confs/app1-deployment.yaml
@@ -18,6 +18,17 @@ spec:
         image: nginx
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: html
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+      volumes:
+      - name: html
+        configMap:
+          name: app1-html
+          items:
+          - key: index.html
+            path: index.html
 ---
 apiVersion: v1
 kind: Service

--- a/p2/confs/app2-configmap.yaml
+++ b/p2/confs/app2-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app2-html
+  namespace: apps
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <head><title>App 2</title></head>
+      <body><h1>Hello from App 2</h1></body>
+    </html>

--- a/p2/confs/app2-deployment.yaml
+++ b/p2/confs/app2-deployment.yaml
@@ -18,6 +18,17 @@ spec:
         image: nginx
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: html
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+      volumes:
+      - name: html
+        configMap:
+          name: app2-html
+          items:
+          - key: index.html
+            path: index.html
 ---
 apiVersion: v1
 kind: Service

--- a/p2/confs/app3-configmap.yaml
+++ b/p2/confs/app3-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app3-html
+  namespace: apps
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <head><title>App 3</title></head>
+      <body><h1>Hello from App 3</h1></body>
+    </html>

--- a/p2/confs/app3-deployment.yaml
+++ b/p2/confs/app3-deployment.yaml
@@ -18,6 +18,17 @@ spec:
         image: nginx
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: html
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+      volumes:
+      - name: html
+        configMap:
+          name: app3-html
+          items:
+          - key: index.html
+            path: index.html
 ---
 apiVersion: v1
 kind: Service

--- a/p2/scripts/deploy_apps.sh
+++ b/p2/scripts/deploy_apps.sh
@@ -16,9 +16,14 @@ kubectl apply -f /vagrant/confs/app1-configmap.yaml
 echo "[INFO] Deploying App1 with custom HTML"
 kubectl apply -f /vagrant/confs/app1-deployment.yaml
 
+echo "[INFO] Deploying HTML ConfigMap for App2"
+kubectl apply -f /vagrant/confs/app2-configmap.yaml
 
 echo "[INFO] Deploying App2 with 3 replicas"
 kubectl apply -f /vagrant/confs/app2-deployment.yaml
+
+echo "[INFO] Deploying HTML ConfigMap for App3"
+kubectl apply -f /vagrant/confs/app3-configmap.yaml
 
 echo "[INFO] Deploying App3 (default)"
 kubectl apply -f /vagrant/confs/app3-deployment.yaml

--- a/p2/scripts/deploy_apps.sh
+++ b/p2/scripts/deploy_apps.sh
@@ -10,8 +10,12 @@ kubectl rollout status deployment/ingress-nginx-controller -n ingress-nginx
 echo "[INFO] Applying Namespace"
 kubectl apply -f /vagrant/confs/app-namespace.yaml
 
-echo "[INFO] Deploying App1"
+echo "[INFO] Deploying HTML ConfigMap for App1"
+kubectl apply -f /vagrant/confs/app1-configmap.yaml
+
+echo "[INFO] Deploying App1 with custom HTML"
 kubectl apply -f /vagrant/confs/app1-deployment.yaml
+
 
 echo "[INFO] Deploying App2 with 3 replicas"
 kubectl apply -f /vagrant/confs/app2-deployment.yaml


### PR DESCRIPTION
This pull request updates the deployment process for three NGINX-based applications to serve custom HTML content using Kubernetes ConfigMaps. The main improvements are the introduction of ConfigMaps for each app's HTML, modifications to the deployment manifests to mount these ConfigMaps, and updates to the deployment script to apply the new resources in the correct order.

**ConfigMap integration for custom HTML:**

* Added new ConfigMaps (`app1-html`, `app2-html`, `app3-html`) in the `apps` namespace, each containing a custom `index.html` for its respective app. [[1]](diffhunk://#diff-ae8f717b168119ce3a34bf3acf3ec32ee216a4d835f04ddd02b4ee13767e2b2bR1-R12) [[2]](diffhunk://#diff-ab9be35696785985f350109769bcb0a1ac7b12c5e719e37d3b3ed77599612614R1-R12) [[3]](diffhunk://#diff-b0a23bbcb5f0d9ee22a1bb9d859df3313a4267406fbfd229e55a356c090494c9R1-R12)

**Deployment manifest updates:**

* Modified `app1-deployment.yaml`, `app2-deployment.yaml`, and `app3-deployment.yaml` to mount the respective ConfigMap as a read-only volume at `/usr/share/nginx/html`, ensuring each app serves its custom HTML. [[1]](diffhunk://#diff-baf92cdddcb8274309a16cee1cac8ab5e9ffcb98f1ba6acd7c9576e2dc60df71R21-R31) [[2]](diffhunk://#diff-17b1e01908caa8d5a157fb4e1695e1de8c811bb304bfa66283aa797315220db1R21-R31) [[3]](diffhunk://#diff-887ad617c147ccc6caf9c3c5fd49ed7affa2dbd76369543096e828e9d5b0c7b1R21-R31)

**Deployment script improvements:**

* Updated `deploy_apps.sh` to apply each ConfigMap before its corresponding deployment, ensuring the custom HTML is available when the pods start.