### PR TITLE
change repo url on argocd

### DIFF
--- a/bonus/confs/argocd-app.yaml
+++ b/bonus/confs/argocd-app.yaml
@@ -9,9 +9,9 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    repoURL: http://localhost:8082/root/inception-of-things.git
+    repoURL: http://gitlab.gitlab.svc.cluster.local/root/inception-of-things.git
     targetRevision: HEAD
-    path: p3/confs
+    path: bonus/confs
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
This pull request updates the ArgoCD application configuration to point to the correct Git repository and deployment path. These changes ensure that the application is deployed from the intended source and directory.

Configuration updates:

* Changed the `repoURL` in `bonus/confs/argocd-app.yaml` to use the internal GitLab service address instead of `localhost`, ensuring correct repository access within the cluster.
* Updated the `path` from `p3/confs` to `bonus/confs` to deploy the correct set of configuration files.